### PR TITLE
Accordion fix

### DIFF
--- a/app/assets/javascripts/accordion.js
+++ b/app/assets/javascripts/accordion.js
@@ -34,7 +34,7 @@ $(function() {
           var li = $("<li/>");
 
           var div_class = (item.has_children == true) ? "accordion-head" : "accordion-nav-leaf";
-          var div = $("<div/>").addClass(div_class).attr('data-path', item.path);
+          var div = $("<div/>").addClass(div_class).attr('data-path', escape(item.path));
           var a = $("<a/>").attr('href', item.uri).text(item.basename);
           var arrow_class = (item.has_children == true) ?  "accordion-nav-arrow" : ''
           var arrow = $("<span/>").addClass(arrow_class);


### PR DESCRIPTION
`item.path` and `item.basename` had to be escaped.

To escape those, I've refactored the code to use `.text()` and `escape()` method. Those methods escapes the string.
