### PR TITLE
Rack streaming proxy unescape

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,11 +23,12 @@ module Yohoushi
 
     config.middleware.use Rack::StreamingProxy::Proxy do |request|
       next unless Settings.proxy
-      path = CGI.unescape(request.path)
-      if request.path.start_with?('/complex/')
-        $mfclient.get_complex_uri(path[9..-1], request.params)
-      elsif request.path.start_with?('/graph/')
+      if request.path.start_with?('/graph/')
+        path = URI::unescape(request.path) # request.path are passed after uri escaped by rack
         $mfclient.get_graph_uri(path[7..-1], request.params)
+      elsif request.path.start_with?('/complex/')
+        path = URI::unescape(request.path)
+        $mfclient.get_complex_uri(path[9..-1], request.params)
       end
     end
   end

--- a/spec/requests/proxy_spec.rb
+++ b/spec/requests/proxy_spec.rb
@@ -1,13 +1,22 @@
 require 'spec_helper'
 
 # config/application.rb
-
 shared_examples_for "correct_proxy_graph" do
   subject do
     escaped_path = URI::escape(path)
     expected = mfclient.get_graph_uri(path, params)
     stub_request(:get, expected).to_return(status: 200)
     get("graph/#{escaped_path}", params)
+  end
+  it { should == 200 }
+end
+
+shared_examples_for "correct_proxy_complex" do
+  subject do
+    escaped_path = URI::escape(path)
+    expected = mfclient.get_complex_uri(path, params)
+    stub_request(:get, expected).to_return(status: 200)
+    get("complex/#{escaped_path}", params)
   end
   it { should == 200 }
 end
@@ -37,21 +46,26 @@ describe "proxy_graph" do
   end
 
   context 'includes symbol characters (of 4 levels)' do
-    let(:path) { "a/b/> c/> d" }
+    let(:path) { "a/b/> +.c/> +.d" }
     it_should_behave_like 'correct_proxy_graph'
   end
 
   context 'includes symbol characters (of 3 levels)' do
-    let(:path) { "a/b/> c" }
+    let(:path) { "a/b/> +.c" }
     it_should_behave_like 'correct_proxy_graph'
   end
 
   context 'includes symbol characters (of 2 levels)' do
-    let(:path) { "a/> b" }
+    let(:path) { "a/> +.b" }
     it_should_behave_like 'correct_proxy_graph'
   end
 end
 
 describe "proxy_complex" do
-  pending "should be same with proxy_graph"
+  let(:params) { {} }
+
+  context 'normal' do
+    let(:path) { 'a/b/c/d' }
+    it_should_behave_like 'correct_proxy_complex'
+  end
 end


### PR DESCRIPTION
Fix that the rack-streaming-proxy. 

Previously, `GET /graph/a/>b` did not work well, but, now it works. 
