### PR TITLE
acts_as_parameter_object gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'font-awesome-rails' # Font-Awesome web fonts
 # gem 'newrelic_rpm'
 
 gem 'draper' # decorator(view-model)
+gem 'acts_as_parameter_object' # Introduce parameter object, cf. Refactoring: Ruby Edition
 gem "settingslogic"
 gem 'growthforecast-client'
 gem 'multiforecast-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       tzinfo (~> 0.3.37)
     acts-as-taggable-on (2.4.1)
       rails (>= 3, < 5)
+    acts_as_parameter_object (0.0.1)
+      activemodel
     addressable (2.3.5)
     arel (4.0.0)
     atomic (1.1.10)
@@ -248,6 +250,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on
+  acts_as_parameter_object
   ancestry!
   better_errors
   binding_of_caller

--- a/app/models/application_parameter.rb
+++ b/app/models/application_parameter.rb
@@ -1,4 +1,4 @@
 class ApplicationParameter
   include Draper::Decoratable
-  include ActiveModel::Validations
+  include ActsAsParameterObject
 end


### PR DESCRIPTION
I created a simple `acts_as_parameter_object` gem https://github.com/sonots/acts_as_parameter_object just for fun :)

It is actually doing the same thing, but would make explicit to notate `this class is using the parameter object pattern!`. 
