### PR TITLE
require config/environments/production.rb as default

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,8 +4,11 @@ require File.expand_path('../application', __FILE__)
 require File.expand_path("#{Rails.root}/lib/yohoushi/logger")
 Rails.logger = Yohoushi.logger(out: 'log/application.log', shift_age: 3) # shift_age: 0 to stop logrotate
 
-# Initialize the Rails application.
+# Hack: Load production.rb as default if #{ENV['RAILS_ENV']}.rb does not exist
 unless %w[production development test].include?(ENV['RAILS_ENV'])
-  require File.expand_path("#{Rails.root}/config/environments/production")
+  unless File.exists?(File.expand_path("#{Rails.root}/config/environments/#{ENV['RAILS_ENV']}.rb"))
+    require File.expand_path("#{Rails.root}/config/environments/production")
+  end
 end
+# Initialize the Rails application.
 Yohoushi::Application.initialize!


### PR DESCRIPTION
Useful when people use RAILS_ENV other than production, development, test.

Without this patch, people had to `cp config/environments/production.rb config/environments/hoge.rb`.
