### PR TITLE
Signal.trap("TERM")

### DIFF
--- a/vendor/extensions/god/cli/run.rb
+++ b/vendor/extensions/god/cli/run.rb
@@ -3,26 +3,30 @@ require 'god/cli/run'
 module God
   module CLI
     class Run
-      def run_in_front
-        require 'god'
-
-        # ugly workaround to terminate all processes by Ctrl-C
+      def default_run_with_trap
+        # ugly workaround to terminate all processes by Ctrl-C and kill -TERM
         # https://bugs.ruby-lang.org/issues/7917
-        trapped = false
-        Signal.trap('INT') do
-          if !trapped
-            Thread.new do
-              God::CLI::Command.new('stop', @options, ['stop', 'yohoushi'])
-              God::CLI::Command.new('terminate', @options, ['terminate'])
-            end
-            trapped = true
-          else
-            raise 'Interrupted'
-          end
-        end
+        @trapped = false
+        Signal.trap('INT') { try_stop }
+        Signal.trap('TERM') { try_stop }
 
-        default_run
+        default_run_without_trap
       end
+      alias_method :default_run_without_trap, :default_run
+      alias_method :default_run, :default_run_with_trap
+
+      def try_stop
+        if !@trapped
+          Thread.new do
+            God::CLI::Command.new('stop', @options, ['stop', 'yohoushi'])
+            God::CLI::Command.new('terminate', @options, ['terminate'])
+          end
+          @trapped = true
+        else
+          raise 'Interrupted'
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
`Signal.trap(TERM)` to kill unicorn and serverengine processes in along with god by `kill {god_process}` command. 

I am monkey patching `#default_run` https://github.com/mojombo/god/blob/f0866e9dfaeb93cdfa1bf8d1dc51d0d17f8e194e/lib/god/cli/run.rb#L40. 
Singnal.trap is effective for both foreground and background now. 
