### PR TITLE
clear parameter if blank

### DIFF
--- a/app/models/graph_parameter.rb
+++ b/app/models/graph_parameter.rb
@@ -80,21 +80,23 @@ class GraphParameter < ApplicationParameter
 
   # convert back to params
   def to_view_params
+    # Without || '', query parameters become like ?t=d&size=L
+    # With || '', query parameters become like ?to=&from=&t=d&size=L
     {
-      't'      => @t,
-      'from'   => @from,
-      'to'     => @to,
-      'size'   => @view_size,
+      't'      => @t || '',
+      'from'   => @from || '',
+      'to'     => @to || '',
+      'size'   => @view_size || '',
     }
   end
 
   # convert back to params
   def to_list_params
     {
-      't'      => @t,
-      'from'   => @from,
-      'to'     => @to,
-      'size'   => @list_size,
+      't'      => @t || '',
+      'from'   => @from || '',
+      'to'     => @to || '',
+      'size'   => @list_size || '',
     }
   end
 


### PR DESCRIPTION
Continued from #20. 

Previously, query parameter was as `?t=d&size=L`. So, the parameter is merged with the internal session parameters and would become as `?from=xxxx&to=xxxx&t=d&size=L` which results in stateful web design. 

But, in #20, I wanted to have RESTful design so that we can copy and paste the URL, and send it to somebody to see the same display. This patch fixes to be so. 
