### PR TITLE
Use serverengine/daemon_logger, which is multiprocess-safe

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
       railties (>= 4.0.0.beta, < 5.0)
       sass (>= 3.1.10)
       sprockets-rails (~> 2.0.0)
-    serverengine (1.5.3)
+    serverengine (1.5.6)
       sigdump (~> 0.2.2)
     servolux (0.10.0)
     settingslogic (2.0.9)

--- a/lib/yohoushi/logger.rb
+++ b/lib/yohoushi/logger.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require 'serverengine/daemon_logger'
 require 'yaml'
 ENV['RAILS_ENV']  ||= 'production'
 ENV['RAILS_ROOT'] ||= File.expand_path('../../..', __FILE__)
@@ -44,7 +44,7 @@ module Yohoushi
       end
     end
 
-    Logger.new(out, shift_age, shift_size).tap do |logger|
+    ServerEngine::DaemonLogger.new(out, log_rotate_age: shift_age, log_rotate_size: shift_size).tap do |logger|
       logger.formatter = block
       logger.level = eval("Logger::#{level.upcase}")
     end


### PR DESCRIPTION
See http://blog.livedoor.jp/sonots/archives/32645828.html, and https://github.com/frsyuki/serverengine/issues/9
