### PR TITLE
fix so that worker can reboot gracefully

### DIFF
--- a/app/worker/worker.rb
+++ b/app/worker/worker.rb
@@ -11,6 +11,7 @@ module Worker
   end
 
   def run
+    @stop = false
     logger.info "Yohoushi worker started."
     until @stop
       @processor.process


### PR DESCRIPTION
https://github.com/frsyuki/serverengine restarts gracefully if it receives USR1 or HUP signal. 
It means that the process (and hence, instances) are not initialized again, but just run loop is called again. 

In that case, the instance variables, especially `@stop` must be initialized, otherwrise, the run loop finishes immediately and restarts again and finishes (loop). 
