### PR TITLE
Add &per=[default_per_page] parameter on pagination links as default

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -171,6 +171,7 @@ class GraphsController < ApplicationController
       @graphs = []
     end
     if @graphs.present?
+      params[:per] ||= Kaminari.config.default_per_page # to show &per= parameter on linked url as default
       @graphs = @graphs.page(params[:page]).per(params[:per])
     end
   end


### PR DESCRIPTION
Now, pagination links to urls like `/list_graph/foo/bar?page=2&per=[default_per_page]` (before: `/list_graph/foo/bar?page=2`) as default. 
This change makes it possible for users to guess how to change `per` parameter. 
