### PR TITLE
released rack-streaming-proxy 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'multiforecast-client'
 gem 'acts-as-taggable-on' # tagging
 gem 'ancestry', git: 'https://github.com/sonots/ancestry.git', branch: 'yohoushi' # tree structured model
 gem "kaminari" # paginator
-gem 'rack-streaming-proxy', git: 'https://github.com/yohoushi/rack-streaming-proxy', require: 'rack/streaming_proxy'
+gem 'rack-streaming-proxy', require: 'rack/streaming_proxy'
 
 group :serverengine do
   gem 'serverengine'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
     ancestry (2.0.0)
       activerecord (>= 3.0.0)
 
-GIT
-  remote: https://github.com/yohoushi/rack-streaming-proxy
-  revision: b5d8d16e9886f7fafc403cc6dac6b37694be17de
-  specs:
-    rack-streaming-proxy (1.6.0)
-      rack (>= 1.4)
-      servolux (~> 0.10)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -146,6 +138,9 @@ GEM
     rack (1.5.2)
     rack-mini-profiler (0.1.31)
       rack (>= 1.1.3)
+    rack-streaming-proxy (2.0.1)
+      rack (>= 1.4)
+      servolux (~> 0.10)
     rack-test (0.6.2)
       rack (>= 1.0)
     rails (4.0.2)
@@ -278,7 +273,7 @@ DEPENDENCIES
   pry
   pry-byebug
   rack-mini-profiler
-  rack-streaming-proxy!
+  rack-streaming-proxy
   rails (~> 4.0.0)
   rspec-rails
   sass-rails (~> 4.0.0)


### PR DESCRIPTION
I got ownership of rack-streaming-proxy and released gem version 2.0.1. 
https://rubygems.org/gems/rack-streaming-proxy

Now, we are the maintainers of rack-streaming-proxy, yay!
