### PR TITLE
fix from_to does not work when short_metrics: false

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     mime-types (1.25.1)
     minitest (4.7.5)
     multi_json (1.8.2)
-    multiforecast-client (0.80.0.1)
+    multiforecast-client (0.80.0.2)
       growthforecast-client (>= 0.62.0)
     mysql2 (0.3.12)
     polyglot (0.3.3)


### PR DESCRIPTION
See https://github.com/yohoushi/multiforecast-client/commit/aed97e4a3122b3d60666f43f3f36322cb5b20f61
