### PR TITLE
[WIP] Stop propagating click event to parent items

### DIFF
--- a/app/assets/javascripts/accordion.js
+++ b/app/assets/javascripts/accordion.js
@@ -1,4 +1,12 @@
 // @reference http://coder.blog.uhuru.co.jp/js/easy_accordion
+
+// Stop propagating click event to parent items
+$(function() {
+  $(document).on("click", '.accordion-head a', function(e) {
+    e.stopPropagation();
+  })
+});
+
 $(function() {
   $(document).on("click", '.accordion-head', function() {
     // Add/Remove opened status


### PR DESCRIPTION
Toggle event starts during page jumping when click `a` item on accordion tree, but it should be suppressed.
