### PR TITLE
Index was missing

### DIFF
--- a/db/migrate/20140501115735_add_path_index_to_nodes.rb
+++ b/db/migrate/20140501115735_add_path_index_to_nodes.rb
@@ -1,0 +1,6 @@
+class AddPathIndexToNodes < ActiveRecord::Migration
+  def change
+    add_index :nodes, :path, length: 255 # migration `20130605091736_create_nodes` was wrong
+    add_index :nodes, [:type, :path], length: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130606035720) do
+ActiveRecord::Schema.define(version: 20140501115735) do
 
   create_table "nodes", force: true do |t|
     t.string   "type"
@@ -24,6 +24,9 @@ ActiveRecord::Schema.define(version: 20130606035720) do
     t.string   "ancestry"
     t.integer  "ancestry_depth",             default: 0
   end
+
+  add_index "nodes", ["path"], name: "index_nodes_on_path", length: {"path"=>255}, using: :btree
+  add_index "nodes", ["type", "path"], name: "index_nodes_on_type_and_path", length: {"type"=>nil, "path"=>255}, using: :btree
 
   create_table "taggings", force: true do |t|
     t.integer  "tag_id"


### PR DESCRIPTION
Add necessary indexes. I found that index for path in nodes table is not valid.

On my environment, there are more than 200,000 graphs in InnoDB. I found this bug because I am facing slow queries. When I added about 1,000 graphs to GrowthForecast, then I noticed that adding new graphs by the worker took too long time about over 10 minutes. Also ajax loading in the accordion graph becomes slow. 

Following is slow query log when adding graphs by worker.

```
Count: 1  Time=0.25s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), yohoushi[yohoushi]@localhost
  SELECT  `nodes`.* FROM `nodes`  WHERE `nodes`.`type` IN ('S') AND `nodes`.`path` = 'S' LIMIT N

Count: 1922  Time=0.23s (450s)  Lock=0.00s (0s)  Rows=0.0 (0), yohoushi[yohoushi]@localhost
  SELECT  `nodes`.* FROM `nodes`  WHERE `nodes`.`type` IN ('S') AND `nodes`.`path` = 'S'  ORDER BY `nodes`.`id` ASC LIMIT N

Count: 8017  Time=0.09s (749s)  Lock=0.00s (0s)  Rows=0.9 (7563), yohoushi[yohoushi]@localhost
  SELECT  id FROM `nodes`  WHERE `nodes`.`type` IN ('S') AND `nodes`.`path` = 'S'  ORDER BY `nodes`.`id` ASC LIMIT N
```
