### PR TITLE
add ancestry index to nodes

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -68,10 +68,10 @@ class Node < ActiveRecord::Base
 
   # @param nodes [Array] array of nodes
   def self.set_has_graph_child(nodes)
-    # select ancestry from nodes where ancestry IN ('1/1844/1845', '1/1844') and type = 'Graph' group by ancestry;
+    # select ancestry from nodes where type = 'Graph' and ancestry IN ('1/1844/1845', '1/1844') group by ancestry;
     # NOTE: We are overriding `path` method of ancestry gem, so have to construct it like `ancestry/id`
-    childrens = Node.where('ancestry IN (?)', nodes.map {|node| "#{node.ancestry}/#{node.id}" })
-    paths = childrens.where("type = 'Graph'").group(:ancestry).pluck(:ancestry)
+    childrens = Node.where("type = 'Graph'").where('ancestry IN (?)', nodes.map {|node| "#{node.ancestry}/#{node.id}" })
+    paths = childrens.group(:ancestry).pluck(:ancestry)
     hash = Hash[*paths.zip([true]*paths.size).flatten]
     nodes.each {|node| node.has_graph_child = hash["#{node.ancestry}/#{node.id}"] || false }
   end

--- a/db/migrate/20141216115735_add_ancestry_index_to_nodes.rb
+++ b/db/migrate/20141216115735_add_ancestry_index_to_nodes.rb
@@ -1,0 +1,6 @@
+class AddAncestryIndexToNodes < ActiveRecord::Migration
+  def change
+    add_index :nodes, [:ancestry], length: 255 # `20130606035720_add_ancestry_to_nodes.rb` was not working
+    add_index :nodes, [:type, :ancestry], length: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140528154712) do
+ActiveRecord::Schema.define(version: 20141216115735) do
 
   create_table "nodes", force: true do |t|
     t.string   "type"
@@ -25,7 +25,9 @@ ActiveRecord::Schema.define(version: 20140528154712) do
     t.integer  "ancestry_depth",             default: 0
   end
 
+  add_index "nodes", ["ancestry"], name: "index_nodes_on_ancestry", using: :btree
   add_index "nodes", ["path"], name: "index_nodes_on_path", length: {"path"=>255}, using: :btree
+  add_index "nodes", ["type", "ancestry"], name: "index_nodes_on_type_and_ancestry", using: :btree
   add_index "nodes", ["type", "path"], name: "index_nodes_on_type_and_path", length: {"type"=>nil, "path"=>255}, using: :btree
 
   create_table "taggings", force: true do |t|


### PR DESCRIPTION
@niku4i 

Same thing with https://github.com/yohoushi/yohoushi/commit/3e507b1b006d0440bab7a5ecae866036d6af6a8d

```
$ mysql -uroot yohoushi;
mysql> set global log_queries_not_using_indexes = 1;
mysql> set global long_query_time = 10;
mysql> set global slow_query_log_file = '/tmp/slowquery.log';
$ mysqldumpslow /tmp/slowquery.log
Count: 1  Time=0.12s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost  SELECT `nodes`.`ancestry` FROM `nodes`  WHERE (ancestry IN ('S','S','S','S')) AND (type = 'S') GROUP BY ancestry

Count: 1  Time=0.08s (0s)  Lock=0.00s (0s)  Rows=4.0 (4), root[root]@localhost
  SELECT `nodes`.* FROM `nodes`  WHERE `nodes`.`ancestry` = 'S' AND `nodes`.`visible` = N  ORDER BY path ASC, type DESC

Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
  SELECT  `nodes`.* FROM `nodes`  WHERE `nodes`.`ancestry` IS NULL  ORDER BY `nodes`.`id` ASC LIMIT N

Count: 72  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (72), root[root]@localhost
  SELECT  id FROM `nodes`  WHERE `nodes`.`type` IN ('S') AND `nodes`.`ancestry` IS NULL  ORDER BY `nodes`.`id` ASC LIMIT N
```

visible is just true or false, so I ignored. 
