### PR TITLE
Fix for the case of that signal is sent repeatedly by sudo

### DIFF
--- a/vendor/extensions/god/cli/run.rb
+++ b/vendor/extensions/god/cli/run.rb
@@ -22,8 +22,6 @@ module God
             God::CLI::Command.new('terminate', @options, ['terminate'])
           end
           @trapped = true
-        else
-          raise 'Interrupted'
         end
       end
 


### PR DESCRIPTION
@niku4i 

https://gist.github.com/sonots/fa995cf73b9824ebb508

To prohibit yohoushi to be aborted before stopping unicorn/serverengine, I had to remove `raise`.
