### PR TITLE
Add option to change unicorn worker num

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -4,6 +4,7 @@ defaults: &defaults
       '': 'http://localhost:5125'
   unicorn:
     port: 4804
+    worker_processes: 4
   tagcloud:
     limit: 400
   accordion:

--- a/config/unicorn.conf
+++ b/config/unicorn.conf
@@ -5,7 +5,7 @@ settings = YAML.load_file("#{ENV['RAILS_ROOT']}/config/application.yml")[ENV['RA
 bind = settings['bind'] || '0.0.0.0'
 port = settings['port'] || '4804'
 
-worker_processes 4
+worker_processes settings['worker_processes'] || 4
 timeout 6000
 listen "#{bind}:#{port}"
 pid File.expand_path('log/unicorn.pid', ENV['RAILS_ROOT'])


### PR DESCRIPTION
Increasing worker num makes page rendering with a lot of graphs faster. This is because each unicorn worker is consumed for getting an image, so default 4 may be a little bit small. But anyway let's keep 4 as default.