### PR TITLE
fix serverengine to stop immediately

### DIFF
--- a/app/worker/worker.rb
+++ b/app/worker/worker.rb
@@ -24,4 +24,12 @@ module Worker
   def stop
     @stop = true
   end
+
+  def wait(time)
+    wait_until = Time.now + time
+    yield
+    while Time.now < wait_until and !@stop
+      sleep 0.1
+    end
+  end
 end

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -19,11 +19,4 @@ module Util
       $stderr.puts "#{e.class} #{e.message}"
     end
   end
-
-  def wait(time)
-    start_time = Time.now
-    yield
-    sleep_time = time - (Time.now - start_time)
-    sleep sleep_time if sleep_time > 0
-  end
 end


### PR DESCRIPTION
@niku4i Previously, we were not seeing `@stop` flag, so we could not stop serverengine immediately with Ctrl-C or SIGTERM. This pull request fixes the issue. 