### PR TITLE
Fix Mysql2::Error: Got a packet bigger than 'max_allowed_packet' bytes

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -159,8 +159,8 @@ class GraphsController < ApplicationController
         @tags = @graphs.tag_counts_on(:tags)
         tags_size = @graphs.tags_on(:tags).size
       else
-        @tags = Graph.tag_counts_on(:tags)
-        tags_size = Tag.all.size # I did not like to post the above big query just for count(*). This was faster
+        @tags = Tag.all
+        tags_size = Tag.all.size
       end
 
       limit = params[:limit].try(:to_i) || Settings.try(:tagcloud).try(:limit) || 400

--- a/app/decorators/node_decorator.rb
+++ b/app/decorators/node_decorator.rb
@@ -40,7 +40,11 @@ class NodeDecorator < ApplicationDecorator
   end
 
   def tag_graph_path(tag_list)
-    h.tag_graph_path(tag_list, graph_parameter_list_params)
+    if tag_list.present?
+      h.tag_graph_path(tag_list, graph_parameter_list_params)
+    else
+      h.tag_graph_root_path(graph_parameter_list_params)
+    end
   end
 
   def setup_graph_path


### PR DESCRIPTION
I got an error like

```
Mysql2::Error: Got a packet bigger than 'max_allowed_packet' bytes: SELECT  tags.*, taggings.tags_count AS count FROM `tags` JOIN (SELECT taggings.tag_id, COUNT(taggings.tag_id) AS tags_count FROM `taggings` INNER JOIN nodes ON nodes.id = taggings.taggable_id AND nodes.type = 'Graph' WHERE (taggings.taggable_type = 'Node' AND taggings.context = 'tags') AND (taggings.taggable_id IN (18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,188593,188594,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,188597,188598,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,188599,188600,173165,173166,173167,173168,173169,173170,173171,173172,173173,173174,173175,173176,173177,188595,188596,393,394,395,396,397,398,399,400,401,402,403,404,405,406,407,408,409,188601,188602,412,413,414,415,416,417,418,419,420,421,422,423,424,425,426,427,428,188607,188608,46554,46555,46556,46557,46558,
```

It seems that the client query is too big in terms of bytes. 

Because, currently, the tagcloud is sorted in alphabetical order rather than tag count order, I noticed that

```
Graph.tag_counts_on(:tags)
```

can be simply

```
Tag.all
```

(except garbage tags which nobody uses)