### PR TITLE
Update god and rack-mini-profiler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     gem-open (0.1.6)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    god (0.13.2)
+    god (0.13.6)
     growthforecast-client (0.80.1)
       httpclient
       thor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
       byebug (~> 1.6)
       pry (~> 0.9.12)
     rack (1.6.4)
-    rack-mini-profiler (0.1.31)
+    rack-mini-profiler (0.9.7)
       rack (>= 1.1.3)
     rack-streaming-proxy (2.0.1)
       rack (>= 1.4)


### PR DESCRIPTION
I found failure of god gem on Mac with ruby 2.2.3 when running bin/yohoushi. God seemd it had bugs when running with ruby 2.2.x so I updated it. Also updated rack-mini-profiler gem because it failed if RAILS_ENV=development.