### PR TITLE
Show sum up total of complex graphs

### DIFF
--- a/app/helpers/graphs_helper.rb
+++ b/app/helpers/graphs_helper.rb
@@ -6,13 +6,13 @@ module GraphsHelper
   def graph_uri_for(graph)
     if Settings.proxy
       if graph.complex
-        proxy_complex_path(graph.path, @graph_parameter.graph_uri_params)
+        proxy_complex_path(graph.path, @graph_parameter.complex_graph_uri_params)
       else
         proxy_graph_path(graph.path, @graph_parameter.graph_uri_params)
       end
     else
       if graph.complex
-        $mfclient.get_complex_uri(graph.path, @graph_parameter.graph_uri_params)
+        $mfclient.get_complex_uri(graph.path, @graph_parameter.complex_graph_uri_params)
       else
         $mfclient.get_graph_uri(graph.path, @graph_parameter.graph_uri_params)
       end

--- a/app/models/graph_parameter.rb
+++ b/app/models/graph_parameter.rb
@@ -1,5 +1,5 @@
 class GraphParameter < ApplicationParameter
-  attr_reader :t, :from, :to, :lower_limit, :upper_limit
+  attr_reader :t, :from, :to, :lower_limit, :upper_limit, :sumup
   alias :term :t
 
   SHORTABLE_TERMS = %w(c h 4h n 8h d 3d)
@@ -12,6 +12,9 @@ class GraphParameter < ApplicationParameter
   end
 
   def initialize(params = {})
+    # @sumup only can be set from application.yml, can not be set from the
+    # query of uri so that the fixed value is set here.
+    @sumup = Settings.sumup ? '1' : '0'
     update(params)
   end
 
@@ -133,6 +136,13 @@ class GraphParameter < ApplicationParameter
     }
     params['notitle'] = '1' if notitle
     params
+  end
+
+  # query parameters passed to growthforecast's complex graph image uri
+  def complex_graph_uri_params
+    graph_uri_params.merge(
+      'sumup'  => @sumup || '',
+    )
   end
 
   private

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -9,4 +9,8 @@ class Settings < Settingslogic
   def auto_tagging
     has_key?('auto_tagging') ? fetch('auto_tagging') : true # default: true
   end
+
+  def sumup
+    has_key?('sumup') ? fetch('sumup') : false # default: false
+  end
 end

--- a/spec/models/graph_parameter_spec.rb
+++ b/spec/models/graph_parameter_spec.rb
@@ -28,6 +28,7 @@ describe GraphParameter do
       its(:size) { should == 'thumbnail' }
       its(:lower_limit) { should be_nil }
       its(:upper_limit) { should be_nil }
+      its(:sumup) { should eq '0' }
     end
 
     context "valid" do


### PR DESCRIPTION
GrowthForecast supports sumup=1 param to show sum up total of complex graph which is displayed at bottom of graph images. I want to add this feature to Yohoushi too.

Note that the default value of sumup is false to keep previous behavior.